### PR TITLE
Create homepage hero, metrics, and featured projects sections

### DIFF
--- a/src/components/FeaturedProjects.astro
+++ b/src/components/FeaturedProjects.astro
@@ -1,0 +1,70 @@
+---
+import projects from '~/data/projects.json';
+
+interface Project {
+  title: string;
+  tagline: string;
+  tags: string[];
+  repoUrl?: string;
+  caseStudyUrl?: string;
+}
+
+const projectList = (projects as Project[]) ?? [];
+const featured = projectList.slice(0, 5);
+---
+<section class="relative mt-20">
+  <div class="absolute inset-0 -z-10 rounded-[2.5rem] border border-slate-800/70 bg-surface/50 blur-3xl"></div>
+  <div class="mx-auto max-w-6xl rounded-3xl border border-slate-800/80 bg-surface-elevated/70 px-6 py-16 shadow-[0_0_90px_-40px_rgba(6,182,212,0.65)] backdrop-blur sm:px-10">
+    <div class="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+      <div>
+        <p class="font-mono text-xs uppercase tracking-[0.5em] text-accent-light/80">// featured work</p>
+        <h2 class="mt-3 text-3xl font-semibold text-white sm:text-4xl">Selected projects</h2>
+        <p class="mt-2 max-w-2xl text-base text-slate-300">
+          A sampling of experiments, production launches, and toolkits that improved velocity and reliability for product teams.
+        </p>
+      </div>
+      <a
+        href="/projects"
+        class="inline-flex items-center justify-center rounded-full border border-slate-700/80 px-5 py-2.5 text-sm font-medium text-slate-100 transition hover:border-accent hover:text-accent-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      >
+        Browse all projects
+      </a>
+    </div>
+    <div class="mt-12 grid gap-8 md:grid-cols-2">
+      {(featured.length ? featured : projectList).slice(0, 4).map((project) => (
+        <article class="group flex h-full flex-col justify-between rounded-2xl border border-slate-800/70 bg-slate-900/40 p-8 shadow-[0_35px_120px_-45px_rgba(6,182,212,0.6)] transition hover:border-accent/80">
+          <div class="space-y-4">
+            <div class="flex flex-wrap gap-2">
+              {project.tags.map((tag) => (
+                <span class="inline-flex items-center rounded-full border border-accent/30 bg-accent/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-accent-light">
+                  {tag}
+                </span>
+              ))}
+            </div>
+            <h3 class="text-2xl font-semibold text-white">{project.title}</h3>
+            <p class="text-base text-slate-300">{project.tagline}</p>
+          </div>
+          <div class="mt-8 flex flex-wrap gap-3">
+            {project.repoUrl && (
+              <a
+                href={project.repoUrl}
+                class="inline-flex items-center justify-center rounded-full border border-transparent bg-accent px-5 py-2 text-sm font-medium text-slate-900 transition hover:bg-accent-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+                rel="noopener noreferrer"
+              >
+                View on GitHub
+              </a>
+            )}
+            {project.caseStudyUrl && (
+              <a
+                href={project.caseStudyUrl}
+                class="inline-flex items-center justify-center rounded-full border border-slate-700/70 bg-surface/70 px-5 py-2 text-sm font-medium text-slate-100 transition hover:border-accent hover:text-accent-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+              >
+                Read case study
+              </a>
+            )}
+          </div>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/components/Hero.astro
+++ b/src/components/Hero.astro
@@ -1,0 +1,36 @@
+---
+const accentId = `hero-accent-${Math.random().toString(36).slice(2, 7)}`;
+---
+<section class="relative overflow-hidden rounded-3xl border border-slate-800/70 bg-surface/80 px-6 py-16 shadow-[0_0_80px_-40px_rgba(6,182,212,0.75)] backdrop-blur md:px-12 md:py-20">
+  <div
+    id={accentId}
+    class="pointer-events-none absolute -top-20 right-10 h-56 w-56 rounded-full bg-gradient-to-br from-accent/40 via-transparent to-transparent opacity-60 blur-3xl transition-transform duration-[4500ms] ease-in-out motion-safe:animate-[spin_22s_linear_infinite]"
+    aria-hidden="true"
+  ></div>
+  <div class="relative flex flex-col gap-8 text-slate-200">
+    <p class="font-mono text-sm uppercase tracking-[0.4em] text-accent-light/90">// portfolio</p>
+    <div class="space-y-6">
+      <h1 class="text-4xl font-semibold leading-tight text-white sm:text-5xl lg:text-6xl">
+        Hi, I'm <span class="text-accent-light">HackAll360</span>. I craft resilient platforms and joyful developer experiences.
+      </h1>
+      <p class="max-w-3xl text-lg text-slate-300 sm:text-xl">
+        Systems engineer, documentation advocate, and experiment-driven builder. I thrive at the intersection of reliability,
+        tooling, and human-centered operations.
+      </p>
+    </div>
+    <div class="flex flex-wrap gap-4">
+      <a
+        href="/projects"
+        class="inline-flex items-center justify-center rounded-full border border-transparent bg-accent px-6 py-3 font-medium text-slate-900 shadow-lg shadow-cyan-500/20 transition hover:bg-accent-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent-light"
+      >
+        View projects
+      </a>
+      <a
+        href="/about"
+        class="inline-flex items-center justify-center rounded-full border border-slate-700/80 bg-surface-elevated/60 px-6 py-3 font-medium text-slate-100 transition hover:border-accent hover:text-accent-light focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      >
+        Learn more about me
+      </a>
+    </div>
+  </div>
+</section>

--- a/src/components/MetricsStrip.astro
+++ b/src/components/MetricsStrip.astro
@@ -1,0 +1,38 @@
+---
+const metrics: Array<{ label: string; value: string; description: string }> = [
+  {
+    label: 'Production launches',
+    value: '35+',
+    description: 'Shipped across platform, growth, and observability initiatives.'
+  },
+  {
+    label: 'Incidents led',
+    value: '20%',
+    description: 'Reduction in meantime-to-recovery by leading on-call and playbook revamps.'
+  },
+  {
+    label: 'Docs published',
+    value: '120+',
+    description: 'Guides, runbooks, and RFCs keeping teams aligned and unblocked.'
+  }
+];
+---
+<section class="relative isolate mt-16 overflow-hidden rounded-3xl border border-slate-800/80 bg-surface-elevated/70 py-10 shadow-[0_0_60px_-30px_rgba(45,212,191,0.6)]">
+  <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(20,184,166,0.18),_transparent_65%)] opacity-70" aria-hidden="true"></div>
+  <div class="relative mx-auto flex max-w-6xl flex-col gap-8 px-6 sm:px-10">
+    <h2 class="font-mono text-xs uppercase tracking-[0.5em] text-accent-light/80">// by the numbers</h2>
+    <div class="grid gap-6 sm:grid-cols-3">
+      {metrics.map((metric) => (
+        <article
+          class="group rounded-2xl border border-slate-700/70 bg-slate-900/40 p-6 text-left shadow-inner transition hover:border-accent/70 focus-within:border-accent/70"
+        >
+          <h3 class="text-3xl font-semibold text-white sm:text-4xl" aria-label={`${metric.value} ${metric.label}`}>
+            {metric.value}
+          </h3>
+          <p class="mt-1 font-semibold uppercase tracking-wide text-accent-light">{metric.label}</p>
+          <p class="mt-3 text-sm text-slate-300">{metric.description}</p>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,0 +1,29 @@
+[
+  {
+    "title": "Observability Toolkit",
+    "tagline": "Unified dashboards and runbooks aligning engineers around actionable telemetry.",
+    "tags": ["SRE", "Dashboards", "Playbooks"],
+    "repoUrl": "https://github.com/hackall360/observability-toolkit",
+    "caseStudyUrl": "/projects/observability-toolkit"
+  },
+  {
+    "title": "Deploy Orchestrator",
+    "tagline": "Progressive delivery pipelines with built-in guardrails and chat-ops controls.",
+    "tags": ["Platform", "CI/CD", "Automation"],
+    "repoUrl": "https://github.com/hackall360/deploy-orchestrator",
+    "caseStudyUrl": "/projects/deploy-orchestrator"
+  },
+  {
+    "title": "Incident Collaboration Kit",
+    "tagline": "Lightweight incident command center integrating status pages, retros, and ownership maps.",
+    "tags": ["Reliability", "Collaboration", "Tooling"],
+    "repoUrl": "https://github.com/hackall360/incident-collab-kit",
+    "caseStudyUrl": "/projects/incident-collab-kit"
+  },
+  {
+    "title": "Developer Portal",
+    "tagline": "Self-serve documentation and golden paths for internal services and APIs.",
+    "tags": ["DX", "Docs", "Guides"],
+    "caseStudyUrl": "/projects/developer-portal"
+  }
+]

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,56 +1,25 @@
 ---
 import BaseLayout from '~/layouts/BaseLayout.astro';
+import Hero from '~/components/Hero.astro';
+import MetricsStrip from '~/components/MetricsStrip.astro';
+import FeaturedProjects from '~/components/FeaturedProjects.astro';
 
 const structuredData = {
   '@context': 'https://schema.org',
   '@type': 'Person',
   name: 'HackAll360',
   url: 'https://hackall360.github.io',
-  sameAs: [
-    'https://github.com/hackall360',
-    'https://www.linkedin.com/in/hackall360'
-  ]
+  sameAs: ['https://github.com/hackall360', 'https://www.linkedin.com/in/hackall360']
 };
 ---
-<BaseLayout title="HackAll360 // Build, Break, Iterate" description="Explorations in shipping, debugging, and continuous learning." structuredData={structuredData}>
-  <section class="mx-auto max-w-5xl px-6 py-20">
-    <div class="relative overflow-hidden rounded-3xl border border-slate-800/80 bg-surface/70 p-10 shadow-[0_0_60px_-20px_rgba(6,182,212,0.6)] backdrop-blur">
-      <div class="pointer-events-none absolute -inset-1 rounded-[inherit] border border-accent/30 opacity-60"></div>
-      <div class="pointer-events-none absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(14,165,233,0.2),_transparent_55%)]"></div>
-      <div class="relative flex flex-col gap-10">
-        <div class="space-y-4">
-          <p class="font-mono text-sm uppercase tracking-[0.3em] text-accent-light">// greeting</p>
-          <h2 class="text-4xl font-semibold text-white sm:text-5xl">
-            Shipping reliable systems with a <span class="text-accent">hacker’s curiosity</span>.
-          </h2>
-          <p class="text-lg text-slate-300">
-            I build focused experiences, automate away toil, and write the docs I wish I had. Currently exploring
-            systems engineering, observability, and high-trust teams.
-          </p>
-        </div>
-        <div class="grid gap-6 md:grid-cols-2">
-          <article class="group relative overflow-hidden rounded-2xl border border-slate-800/80 bg-surface-elevated/80 p-6 shadow-[0_0_30px_-15px_rgba(8,145,178,0.6)] transition">
-            <div class="absolute -inset-px rounded-2xl border border-transparent bg-gradient-to-br from-accent/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
-            <div class="relative">
-              <h3 class="font-mono text-sm uppercase tracking-widest text-accent-light">Current focus</h3>
-              <p class="mt-3 text-base text-slate-200">
-                Leading platform initiatives that keep releases fast, safe, and observable. Shipping dashboards, CLI tools,
-                and playbooks.
-              </p>
-            </div>
-          </article>
-          <article class="group relative overflow-hidden rounded-2xl border border-slate-800/80 bg-surface-elevated/80 p-6 shadow-[0_0_30px_-15px_rgba(6,182,212,0.6)] transition">
-            <div class="absolute -inset-px rounded-2xl border border-transparent bg-gradient-to-br from-accent/20 via-transparent to-transparent opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
-            <div class="relative">
-              <h3 class="font-mono text-sm uppercase tracking-widest text-accent-light">What’s next</h3>
-              <p class="mt-3 text-base text-slate-200">
-                Curating a Now page to track experiments in public and building a home for long-form notes about process and
-                practice.
-              </p>
-            </div>
-          </article>
-        </div>
-      </div>
-    </div>
-  </section>
+<BaseLayout
+  title="HackAll360 | Systems Engineer & Platform Builder"
+  description="Portfolio of HackAll360 — systems engineer crafting reliable platforms, resilient tooling, and developer experiences."
+  structuredData={structuredData}
+>
+  <div class="relative mx-auto flex max-w-6xl flex-col gap-16 px-6 py-24 sm:px-10 lg:py-28">
+    <Hero />
+    <MetricsStrip />
+    <FeaturedProjects />
+  </div>
 </BaseLayout>


### PR DESCRIPTION
## Summary
- add dedicated hero, metrics, and featured project components styled for the dark theme
- populate a projects data source and render cards with CTAs on the homepage
- compose the updated homepage using BaseLayout with refreshed metadata

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68f4d82ce678832f89051d0eda3e4ade