### PR TITLE
Add GitHub project fetcher automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ dist/
 .env
 .env.*
 .DS_Store
+
+# Project data fetcher artifacts
+scripts/*.cache.json
+scripts/*.tmp
+scripts/tmp/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
 # hackall360.github.io
+
+Personal site built with [Astro](https://astro.build/).
+
+## Requirements
+
+- Node.js 18 or later
+- npm 9 or later
+- (Recommended) A GitHub personal access token with `public_repo` scope exposed as `GITHUB_TOKEN` when running project automation scripts.
+
+## Environment variables
+
+The project fetcher script reads the following optional variables:
+
+| Variable | Purpose |
+| --- | --- |
+| `GITHUB_TOKEN` | Raises GitHub API rate limits and avoids anonymous throttling. |
+| `GITHUB_OWNER` | Overrides the default GitHub account (`hackall360`). |
+| `GITHUB_MIN_STARS` | Minimum star threshold for repositories to be included (default: `0`). |
+| `GITHUB_INCLUDE_TOPICS` | Comma-separated list of topics; at least one must match for a repository to be included. |
+| `GITHUB_FEATURE_TOPIC` | Topic name that marks a repository as `featured` (default: `featured`). |
+| `GITHUB_CASE_STUDY_TOPIC` | Topic that enables automatic `/projects/<slug>` case study links (default: `case-study`). |
+| `GITHUB_CASE_STUDY_PREFIX` | Topic prefix that encodes explicit case-study slugs (default: `case-study:`). |
+| `GITHUB_PROJECTS_OUTPUT` | Output path for the generated JSON data (default: `src/data/projects.json`). |
+| `GITHUB_PROXY` | Proxy URL to override environment proxy settings when calling the GitHub API. |
+
+If your network requires a proxy, set `GITHUB_PROXY` or rely on `HTTPS_PROXY`/`HTTP_PROXY`, which the script respects automatically.
+
+## Fetching project metadata
+
+Use the `fetch-projects` script to synchronize local project data with GitHub:
+
+```bash
+npm install
+GITHUB_TOKEN="<token>" npm run fetch-projects
+```
+
+The command writes a deterministic, sorted list of repositories to `src/data/projects.json` with the following shape:
+
+```json
+[
+  {
+    "slug": "repo-name",
+    "name": "repo-name",
+    "description": "",
+    "tags": ["topic-a", "topic-b"],
+    "stars": 42,
+    "language": "TypeScript",
+    "url": "https://github.com/hackall360/repo-name",
+    "caseStudy": "/projects/repo-name",
+    "featured": true
+  }
+]
+```
+
+Add the `featured` topic to highlight a project on the home page. For case studies, either use the `case-study` topic (default route `/projects/<slug>`) or add a topic such as `case-study:custom-slug` for custom paths.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Open http://localhost:4321/ to iterate locally.
+
+## Production build
+
+```bash
+npm run build
+npm run preview
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "hackall360-github-io",
       "version": "0.0.1",
       "dependencies": {
-        "astro": "^4.16.12"
+        "astro": "^4.16.12",
+        "undici": "^7.16.0"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.4",
@@ -6512,6 +6513,15 @@
       "license": "MIT",
       "dependencies": {
         "semver": "^7.3.8"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.16.0.tgz",
+      "integrity": "sha512-QEg3HPMll0o3t2ourKwOeUAZ159Kn9mx5pnzHRQO8+Wixmh88YdZRiIwat0iNzNNXn0yoEtXJqFpyW7eM8BV7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unified": {

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "dev": "astro dev",
     "build": "astro build",
     "preview": "astro preview",
-    "astro:check": "astro check"
+    "astro:check": "astro check",
+    "fetch-projects": "node ./scripts/fetch-projects.mjs"
   },
   "dependencies": {
-    "astro": "^4.16.12"
+    "astro": "^4.16.12",
+    "undici": "^7.16.0"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.4",

--- a/scripts/fetch-projects.mjs
+++ b/scripts/fetch-projects.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+import { mkdir, writeFile } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import process from 'node:process';
+import { fetch, ProxyAgent, setGlobalDispatcher } from 'undici';
+
+const proxyUrl =
+  process.env.GITHUB_PROXY ??
+  process.env.HTTPS_PROXY ??
+  process.env.https_proxy ??
+  process.env.HTTP_PROXY ??
+  process.env.http_proxy ??
+  null;
+
+if (proxyUrl) {
+  setGlobalDispatcher(new ProxyAgent(proxyUrl));
+}
+
+const OWNER = process.env.GITHUB_OWNER ?? 'hackall360';
+const PER_PAGE = Number.parseInt(process.env.GITHUB_PER_PAGE ?? '100', 10);
+const MIN_STARS = Number.parseInt(process.env.GITHUB_MIN_STARS ?? '0', 10);
+const INCLUDE_TOPICS = (process.env.GITHUB_INCLUDE_TOPICS ?? '')
+  .split(',')
+  .map((topic) => topic.trim().toLowerCase())
+  .filter(Boolean);
+const FEATURE_TOPIC = (process.env.GITHUB_FEATURE_TOPIC ?? 'featured').toLowerCase();
+const CASE_STUDY_TOPIC = (process.env.GITHUB_CASE_STUDY_TOPIC ?? 'case-study').toLowerCase();
+const CASE_STUDY_PREFIX = (process.env.GITHUB_CASE_STUDY_PREFIX ?? 'case-study:').toLowerCase();
+const OUTPUT_PATH = resolve(process.cwd(), process.env.GITHUB_PROJECTS_OUTPUT ?? 'src/data/projects.json');
+const API_BASE = 'https://api.github.com';
+const token = process.env.GITHUB_TOKEN;
+
+const headers = {
+  'User-Agent': 'hackall360-project-fetcher',
+  Accept: 'application/vnd.github+json',
+  'X-GitHub-Api-Version': '2022-11-28',
+};
+
+if (token) {
+  headers.Authorization = `Bearer ${token}`;
+}
+
+async function githubRequest(endpoint, params = {}) {
+  const url = new URL(endpoint, API_BASE);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null) {
+      url.searchParams.set(key, String(value));
+    }
+  });
+
+  const response = await fetch(url, { headers });
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(`GitHub request failed (${response.status} ${response.statusText}): ${message}`);
+  }
+
+  return response.json();
+}
+
+async function fetchAllRepos() {
+  let page = 1;
+  const repos = [];
+
+  while (true) {
+    const pageData = await githubRequest(`/users/${OWNER}/repos`, {
+      per_page: PER_PAGE,
+      page,
+      sort: 'updated',
+    });
+
+    if (!Array.isArray(pageData) || pageData.length === 0) {
+      break;
+    }
+
+    repos.push(...pageData);
+
+    if (pageData.length < PER_PAGE) {
+      break;
+    }
+
+    page += 1;
+  }
+
+  return repos;
+}
+
+async function fetchTopics(repoName) {
+  const data = await githubRequest(`/repos/${OWNER}/${repoName}/topics`);
+  return Array.isArray(data.names) ? data.names : [];
+}
+
+function shouldIncludeRepo(repo, topics) {
+  if (repo.archived || repo.disabled || repo.fork) {
+    return false;
+  }
+
+  const starQualified = repo.stargazers_count >= MIN_STARS;
+  const normalizedTopics = topics.map((topic) => topic.toLowerCase());
+  const topicQualified =
+    INCLUDE_TOPICS.length === 0 || INCLUDE_TOPICS.some((topic) => normalizedTopics.includes(topic));
+
+  return starQualified && topicQualified;
+}
+
+function buildCaseStudyPath(topics, slug) {
+  const normalizedTopics = topics.map((topic) => topic.toLowerCase());
+  const prefixed = normalizedTopics.find((topic) => topic.startsWith(CASE_STUDY_PREFIX));
+
+  if (prefixed) {
+    const suffix = prefixed.slice(CASE_STUDY_PREFIX.length);
+    return suffix ? `/projects/${suffix}` : `/projects/${slug}`;
+  }
+
+  if (normalizedTopics.includes(CASE_STUDY_TOPIC)) {
+    return `/projects/${slug}`;
+  }
+
+  return null;
+}
+
+function toProject(repo, topics) {
+  const normalizedTopics = topics.map((topic) => topic.toLowerCase());
+  const filteredTags = topics.filter((topic) => {
+    const lower = topic.toLowerCase();
+    return lower !== FEATURE_TOPIC && lower !== CASE_STUDY_TOPIC && !lower.startsWith(CASE_STUDY_PREFIX);
+  });
+
+  return {
+    slug: repo.name,
+    name: repo.name,
+    description: repo.description ?? '',
+    tags: filteredTags,
+    stars: repo.stargazers_count,
+    language: repo.language,
+    url: repo.html_url,
+    caseStudy: buildCaseStudyPath(topics, repo.name),
+    featured: normalizedTopics.includes(FEATURE_TOPIC),
+  };
+}
+
+function sortProjects(projects) {
+  return [...projects].sort((a, b) => {
+    if (a.featured !== b.featured) {
+      return a.featured ? -1 : 1;
+    }
+
+    if (b.stars !== a.stars) {
+      return b.stars - a.stars;
+    }
+
+    return a.slug.localeCompare(b.slug);
+  });
+}
+
+async function main() {
+  try {
+    const repos = await fetchAllRepos();
+    const projects = [];
+
+    for (const repo of repos) {
+      const topics = await fetchTopics(repo.name);
+      if (!shouldIncludeRepo(repo, topics)) {
+        continue;
+      }
+      projects.push(toProject(repo, topics));
+    }
+
+    const sorted = sortProjects(projects);
+    await mkdir(dirname(OUTPUT_PATH), { recursive: true });
+    await writeFile(OUTPUT_PATH, `${JSON.stringify(sorted, null, 2)}\n`);
+
+    console.log(`Wrote ${sorted.length} projects to ${OUTPUT_PATH}`);
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+}
+
+main();

--- a/src/data/projects.json
+++ b/src/data/projects.json
@@ -1,29 +1,123 @@
 [
   {
-    "title": "Observability Toolkit",
-    "tagline": "Unified dashboards and runbooks aligning engineers around actionable telemetry.",
-    "tags": ["SRE", "Dashboards", "Playbooks"],
-    "repoUrl": "https://github.com/hackall360/observability-toolkit",
-    "caseStudyUrl": "/projects/observability-toolkit"
+    "slug": "auto-coder",
+    "name": "auto-coder",
+    "description": "",
+    "tags": [],
+    "stars": 0,
+    "language": "Python",
+    "url": "https://github.com/hackall360/auto-coder",
+    "caseStudy": null,
+    "featured": false
   },
   {
-    "title": "Deploy Orchestrator",
-    "tagline": "Progressive delivery pipelines with built-in guardrails and chat-ops controls.",
-    "tags": ["Platform", "CI/CD", "Automation"],
-    "repoUrl": "https://github.com/hackall360/deploy-orchestrator",
-    "caseStudyUrl": "/projects/deploy-orchestrator"
+    "slug": "hackall360.github.io",
+    "name": "hackall360.github.io",
+    "description": "",
+    "tags": [],
+    "stars": 0,
+    "language": "Astro",
+    "url": "https://github.com/hackall360/hackall360.github.io",
+    "caseStudy": null,
+    "featured": false
   },
   {
-    "title": "Incident Collaboration Kit",
-    "tagline": "Lightweight incident command center integrating status pages, retros, and ownership maps.",
-    "tags": ["Reliability", "Collaboration", "Tooling"],
-    "repoUrl": "https://github.com/hackall360/incident-collab-kit",
-    "caseStudyUrl": "/projects/incident-collab-kit"
+    "slug": "NeoGradleTemplate",
+    "name": "NeoGradleTemplate",
+    "description": "",
+    "tags": [],
+    "stars": 0,
+    "language": "Java",
+    "url": "https://github.com/hackall360/NeoGradleTemplate",
+    "caseStudy": null,
+    "featured": false
   },
   {
-    "title": "Developer Portal",
-    "tagline": "Self-serve documentation and golden paths for internal services and APIs.",
-    "tags": ["DX", "Docs", "Guides"],
-    "caseStudyUrl": "/projects/developer-portal"
+    "slug": "portfolio-lesson-1",
+    "name": "portfolio-lesson-1",
+    "description": "",
+    "tags": [],
+    "stars": 0,
+    "language": "HTML",
+    "url": "https://github.com/hackall360/portfolio-lesson-1",
+    "caseStudy": null,
+    "featured": false
+  },
+  {
+    "slug": "PyGoConverter",
+    "name": "PyGoConverter",
+    "description": "A python to golang language converter written in golang.",
+    "tags": [],
+    "stars": 0,
+    "language": null,
+    "url": "https://github.com/hackall360/PyGoConverter",
+    "caseStudy": null,
+    "featured": false
+  },
+  {
+    "slug": "Software-Development-Course-Git",
+    "name": "Software-Development-Course-Git",
+    "description": "A Github based lesson series in software development -- Git Flow and using git in real-world applications",
+    "tags": [],
+    "stars": 0,
+    "language": null,
+    "url": "https://github.com/hackall360/Software-Development-Course-Git",
+    "caseStudy": null,
+    "featured": false
+  },
+  {
+    "slug": "SOLLOL",
+    "name": "SOLLOL",
+    "description": "FORKED FOR WORKING ON -- Super Ollama Load Balancer - Performance-aware routing for distributed Ollama deployments with Ray, Dask, and adaptive metrics",
+    "tags": [],
+    "stars": 0,
+    "language": "Python",
+    "url": "https://github.com/hackall360/SOLLOL",
+    "caseStudy": null,
+    "featured": false
+  },
+  {
+    "slug": "studio-rust-mcp-server",
+    "name": "studio-rust-mcp-server",
+    "description": "Standalone Roblox Studio MCP Server",
+    "tags": [],
+    "stars": 0,
+    "language": "Luau",
+    "url": "https://github.com/hackall360/studio-rust-mcp-server",
+    "caseStudy": null,
+    "featured": false
+  },
+  {
+    "slug": "SuperToken",
+    "name": "SuperToken",
+    "description": "",
+    "tags": [],
+    "stars": 0,
+    "language": "Python",
+    "url": "https://github.com/hackall360/SuperToken",
+    "caseStudy": null,
+    "featured": false
+  },
+  {
+    "slug": "UnityDiscord",
+    "name": "UnityDiscord",
+    "description": "Unity's GitHub directory for discord chat bot",
+    "tags": [],
+    "stars": 0,
+    "language": null,
+    "url": "https://github.com/hackall360/UnityDiscord",
+    "caseStudy": null,
+    "featured": false
+  },
+  {
+    "slug": "WOTLK-WebServer",
+    "name": "WOTLK-WebServer",
+    "description": "REPLACE ME",
+    "tags": [],
+    "stars": 0,
+    "language": "JavaScript",
+    "url": "https://github.com/hackall360/WOTLK-WebServer",
+    "caseStudy": null,
+    "featured": false
   }
 ]


### PR DESCRIPTION
## Summary
- add an automated script that calls the GitHub REST API, filters repositories, and writes deterministic project data
- document environment variables and npm workflow for fetching project metadata and update gitignore
- seed src/data/projects.json with the latest repository snapshot

## Testing
- npm run fetch-projects

------
https://chatgpt.com/codex/tasks/task_b_68f4d995f95c832fa33be8749d656beb