### PR TITLE
Add GitHub Pages deploy workflow with project caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy site
+
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Compute projects cache key
+        id: cache-key
+        run: echo "day=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Restore projects cache
+        id: projects-cache
+        uses: actions/cache@v4
+        with:
+          path: src/data/projects.json
+          key: projects-${{ github.repository_owner }}-${{ steps.cache-key.outputs.day }}
+          restore-keys: |
+            projects-${{ github.repository_owner }}-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fetch projects
+        if: steps.projects-cache.outputs.cache-hit != 'true'
+        run: npm run fetch-projects
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: npm run build
+
+      - name: Deploy to GitHub Pages
+        uses: withastro/action@v1
+        with:
+          deploy_branch: gh-pages
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The project fetcher script reads the following optional variables:
 | `GITHUB_CASE_STUDY_TOPIC` | Topic that enables automatic `/projects/<slug>` case study links (default: `case-study`). |
 | `GITHUB_CASE_STUDY_PREFIX` | Topic prefix that encodes explicit case-study slugs (default: `case-study:`). |
 | `GITHUB_PROJECTS_OUTPUT` | Output path for the generated JSON data (default: `src/data/projects.json`). |
+| `GITHUB_PROJECTS_CACHE_MAX_AGE_HOURS` | Maximum age in hours before the fetcher refreshes cached data (default: `24`). |
+| `GITHUB_PROJECTS_FORCE_REFRESH` | Set to `true`/`1` to bypass the cache and always hit the GitHub API. |
 | `GITHUB_PROXY` | Proxy URL to override environment proxy settings when calling the GitHub API. |
 
 If your network requires a proxy, set `GITHUB_PROXY` or rely on `HTTPS_PROXY`/`HTTP_PROXY`, which the script respects automatically.
@@ -54,6 +56,23 @@ The command writes a deterministic, sorted list of repositories to `src/data/pro
 ```
 
 Add the `featured` topic to highlight a project on the home page. For case studies, either use the `case-study` topic (default route `/projects/<slug>`) or add a topic such as `case-study:custom-slug` for custom paths.
+
+## Deployment workflow
+
+Automated deploys run through the **Deploy site** GitHub Actions workflow located at `.github/workflows/deploy.yml`.
+
+- **Triggers:** The workflow runs on pushes to `main`, on a nightly schedule (`0 1 * * *` UTC), and manually via the **Run workflow** button exposed through the `workflow_dispatch` trigger.
+- **Dependencies:** The job installs packages with `npm ci` using `actions/setup-node` dependency caching to keep builds fast.
+- **Project data cache:** Before invoking `npm run fetch-projects`, the workflow restores `src/data/projects.json` from the Actions cache keyed by day. If the cache is hit, the fetch step is skipped, preventing unnecessary GitHub API usage. When a refresh is needed, the fetch script honors `GITHUB_PROJECTS_CACHE_MAX_AGE_HOURS` and can use the built-in `GITHUB_TOKEN` to raise rate limits.
+- **Build and deploy:** After building the Astro site (`npm run build`), the job publishes to the `gh-pages` branch using [`withastro/action`](https://github.com/withastro/action). The default `GITHUB_TOKEN` secret supplied by GitHub Actions is sufficient for deployments; no extra secrets are required.
+
+To run the workflow manually:
+
+1. Navigate to **Actions → Deploy site** in the repository on GitHub.
+2. Click **Run workflow**.
+3. Select the desired branch (defaults to `main`) and confirm.
+
+The workflow will restore cached project data when available and only call the GitHub API if a fresh snapshot is required, helping stay well within API rate limits.
 
 ## Development
 


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that builds nightly and deploys the Astro site to `gh-pages`
- reuse cached `projects.json` data between runs to avoid unnecessary GitHub API calls
- document the deployment workflow, cache behaviour, and related environment variables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68f4eceac478832f94768c4208629fd8