### PR TITLE
Grant Pages deploy workflow contents write permission

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- grant the deploy workflow explicit contents write permission to ensure GitHub Pages deployment can push updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f511b50c08832f84456c99f6641412