### PR TITLE
Ensure deploy workflow refreshes projects on pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm ci
 
       - name: Fetch projects
-        if: steps.projects-cache.outputs.cache-hit != 'true'
+        if: github.event_name != 'schedule' || steps.projects-cache.outputs.cache-hit != 'true'
         run: npm run fetch-projects
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- update the deploy workflow so project data is always refreshed on push and manual dispatch runs
- keep scheduled runs gated by the cache hit so they can short-circuit when data is unchanged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68f51ead272c832fac20d1baa78db9d6