### PR TITLE
Add Astro check step to deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Run Astro check
+        run: npm run astro:check
+
       - name: Fetch projects
         if: github.event_name != 'schedule' || steps.projects-cache.outputs.cache-hit != 'true'
         run: npm run fetch-projects


### PR DESCRIPTION
## Summary
- add an `npm run astro:check` step after installing dependencies in the deploy workflow
- ensure schema and type issues fail the job prior to deployment

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68f521034698832f90f089c2be42ae08