### PR TITLE
Ensure deploy workflow validates project data before building

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,14 +40,17 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run Astro check
-        run: npm run astro:check
-
       - name: Fetch projects
         if: github.event_name != 'schedule' || steps.projects-cache.outputs.cache-hit != 'true'
         run: npm run fetch-projects
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify project data file
+        run: test -s src/data/projects.json
+
+      - name: Run Astro check
+        run: npm run astro:check
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
## Summary
- run the project fetch before static analysis and enforce the generated data file exists
- keep Astro check in the pipeline to guard builds against schema mismatches

## Testing
- not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_b_68f4c2eac7a8832f9056ecfa421f7d0b