### PR TITLE
Add four new reliability and platform engineering notes

### DIFF
--- a/src/content/notes/how-i-test-for-secrets-in-prs.md
+++ b/src/content/notes/how-i-test-for-secrets-in-prs.md
@@ -1,0 +1,37 @@
+---
+title: "How I test for secrets in PRs without crying"
+description: "Rotation-friendly guardrails for catching leaked tokens in pull requests without burying reviewers in noise."
+tags:
+  - security
+  - automation
+  - developer-experience
+publishedAt: 2024-10-24
+updatedAt: 2024-10-24
+---
+
+## Why secret scanning kept failing
+
+Shipping fast often meant that sensitive strings drifted into review. Built-in scanners were either tuned so loosely they alerted on
+anything with the word `key`, or so strict they missed scoped tokens entirely. Incident retros pointed to the same three
+failures: reviewers trusted "green" checks blindly, the CI job lagged minutes behind a push, and we had no reliable inventory of
+what secrets actually looked like.
+
+## Guardrails that survived production
+
+- **Inventory first.** We captured real token formats—length, prefixes, entropy—by redacting samples in a private repository.
+  Having a canonical list of patterns let us tighten entropy thresholds and reduce false positives by about 60%.
+- **Dual scanners with intent.** TruffleHog handled entropy-heavy detection while Gitleaks managed explicit patterns. The
+  overlap caught risky strings within 10 seconds of a push.
+- **Reviewer controls.** Findings surfaced as review comments with remediation tips instead of a wall of CI logs. Reviewers could
+  acknowledge, suppress for a single commit, or block the merge entirely.
+- **Auto-rotations wired in.** When a leak triggered, a GitHub Action hit our secrets broker to rotate and revoke the token, then
+  posted clean-up instructions back into the PR thread.
+
+## What stays on my checklist
+
+1. Run the scanners locally via a pre-commit hook before opening the PR.
+2. Confirm the rotation pipeline still functions end-to-end after each dependency upgrade.
+3. Audit suppressions weekly; expired justifications purge themselves after seven days.
+
+These habits keep secret scanning predictable enough that engineers trust the alerts—and fix the leak—without grinding the release
+cycle to a halt.

--- a/src/content/notes/incident-drill-auth-outage.md
+++ b/src/content/notes/incident-drill-auth-outage.md
@@ -1,0 +1,34 @@
+---
+title: "Incident drill: a 45-minute tabletop for auth outages"
+description: "A facilitation kit for running fast-paced rehearsals that expose brittle authentication paths before prod users do."
+tags:
+  - incident-response
+  - facilitation
+  - reliability
+publishedAt: 2024-10-22
+updatedAt: 2024-10-22
+---
+
+## Scenario snapshot
+
+This tabletop simulates a sudden spike of 401 errors after a dependency deploy. The session packs discovery, containment, and
+post-incident commitments into 45 minutes so teams can practice under a controlled clock.
+
+## Prep checklist
+
+- **Cast the roles.** Assign an incident commander, comms lead, and two responders. Observers capture follow-up tasks.
+- **Artifacts ready to share.** Provide mock dashboards, authentication logs, and a changelog excerpt with a hidden regression.
+- **Exit criteria.** Define what "restored" means—users can sign in again, log drains, and the rollback is verified.
+
+## Timeline beats
+
+1. **Kickoff (5 minutes).** Commander sets objectives and constraints; comms lead drafts the first customer update.
+2. **Discovery (10 minutes).** Responders inspect metrics, reproduce failures, and identify the deploy hash.
+3. **Stabilize (15 minutes).** Team decides between rollback and feature flag; commander authorizes mitigation.
+4. **Review (10 minutes).** Everyone outlines two automation or monitoring gaps discovered during the drill.
+5. **Close (5 minutes).** Capture action owners, due dates, and schedule the next rehearsal.
+
+## Debrief cues
+
+Ask participants how confident they felt navigating the runbook, what slowed status updates, and which alerts arrived too late.
+I end the drill with a single commitment: schedule the real fixes while the pain is fresh.

--- a/src/content/notes/kubernetes-slos-that-matter.md
+++ b/src/content/notes/kubernetes-slos-that-matter.md
@@ -1,0 +1,36 @@
+---
+title: "Kubernetes SLOs that matter (and what to ignore)"
+description: "A pragmatic shortlist of cluster SLOs that actually influence customer experience, plus the noisy metrics to skip."
+tags:
+  - observability
+  - kubernetes
+  - reliability
+publishedAt: 2024-10-15
+updatedAt: 2024-10-15
+---
+
+## Focus on signals users feel
+
+I used to track every metric the control plane emitted. The dashboards looked impressive, but outages still surprised us because
+none of the thresholds mapped to user impact. The SLOs that stuck are the ones tied directly to customer experience.
+
+## Core SLOs in rotation
+
+- **Ingress success rate.** 99.9% of HTTPS requests must terminate without 5xx responses attributed to the cluster.
+- **Pod readiness latency.** 95th percentile of pod readiness under 45 seconds keeps deploys snappy and autoscaling believable.
+- **Job completion timeliness.** 99% of CronJobs finish within their scheduled window; misses trigger queue backups we feel in
+  production.
+
+## What I stopped measuring
+
+- **API server request saturation.** The metric spiked often but never correlated with incidents; we now use it as a debugging
+  signal only.
+- **Node disk pressure warnings.** Too noisy with burst workloads; we switched to a direct "free inode" SLI fed into auto-healing
+  scripts.
+- **Control plane component restarts.** Kubernetes healed itself while we chased phantom restarts. We now alert on workload restar
+  ts instead.
+
+## Keeping SLOs honest
+
+Review the error budgets in post-incident reviews, and prune an SLO when it stops driving action. The goal is to keep operators
+focused on the conditions that customers will notice, not the ones that merely fill a dashboard.

--- a/src/content/notes/minimal-sbom-github-actions.md
+++ b/src/content/notes/minimal-sbom-github-actions.md
@@ -1,0 +1,33 @@
+---
+title: "Minimal SBOM + provenance in GitHub Actions"
+description: "The smallest workflow changes needed to generate SBOMs with signed build attestations in GitHub-hosted runners."
+tags:
+  - supply-chain
+  - github-actions
+  - platform-engineering
+publishedAt: 2024-10-18
+updatedAt: 2024-10-18
+---
+
+## Problem framing
+
+Customers demanded artifact transparency, but our CI pipelines only produced build logs. We needed software bills of materials and
+signed provenance without turning every workflow into a research project.
+
+## Workflow adjustments
+
+- **Add a CycloneDX step.** `cyclonedx-gomod` and `cyclonedx-npm` covered Go and Node builds. The artifacts ship as build
+  attachments and upload to our S3 evidence bucket.
+- **Generate provenance via `actions/attest-build-provenance`.** The action signs the build output with GitHub-managed keys and
+  emits an in-toto statement we can verify downstream.
+- **Enforce verification in deployments.** Our CD job refuses to promote artifacts unless both the SBOM and provenance files are
+  attached and validate against the expected digest.
+
+## Ongoing maintenance
+
+- Rotate the attestation verification keys quarterly and document the fingerprint in the runbook.
+- Patch the CycloneDX CLI monthly; new schema versions surface CVE data without extra tooling.
+- Track SBOM upload failures as production alerts—missing evidence is a deploy blocker, not an FYI.
+
+These adjustments kept our compliance reviewers satisfied while staying small enough that engineers could adopt them across
+repositories within a single sprint.


### PR DESCRIPTION
## Summary
- add four new Notes entries covering secrets scanning, auth outage drills, supply chain evidence, and Kubernetes SLOs
- include metadata, accessible headings, and summaries aligned with existing content structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68fae37f78d0832fa27f84de3ac7d50a