### PR TITLE
Add curated tools section to landing page

### DIFF
--- a/src/components/Tools.astro
+++ b/src/components/Tools.astro
@@ -1,0 +1,52 @@
+---
+import Icon from '~/components/Icon.astro';
+import { ICONS } from '~/utils/iconPaths';
+import { tools } from '~/data/tools';
+
+const sectionTitleId = `tools-heading-${Math.random().toString(36).slice(2, 7)}`;
+---
+<section
+  class="rounded-4xl border border-slate-800/60 bg-surface-elevated/70 p-8 text-slate-200 shadow-[0_0_70px_-40px_rgba(34,211,238,0.7)] sm:p-12"
+  aria-labelledby={sectionTitleId}
+>
+  <header class="max-w-3xl space-y-3">
+    <p class="font-mono text-xs uppercase tracking-[0.5em] text-accent-light/80">// tools</p>
+    <h2 id={sectionTitleId} class="text-3xl font-semibold text-white sm:text-4xl">
+      Tooling that keeps delivery fast, observable, and repeatable.
+    </h2>
+    <p class="text-sm leading-relaxed text-slate-300 sm:text-base">
+      Each kit ships with documentation and guardrails so teams can plug into reliable workflows without slowing down onboarding.
+    </p>
+  </header>
+  <div class="mt-10 grid grid-cols-1 gap-6 md:grid-cols-3" role="list">
+    {tools.map((tool) => {
+      const icon = ICONS[tool.icon];
+      const arrow = ICONS.arrowUpRight;
+      return (
+        <article
+          class="group flex h-full flex-col overflow-hidden rounded-3xl border border-slate-700/50 bg-slate-950/40 shadow-inner transition hover:border-accent/60 focus-within:border-accent/60"
+          role="listitem"
+        >
+          <a
+            class="group flex h-full flex-col gap-6 p-6 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+            href={tool.href}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            <span class="flex items-center gap-4">
+              <span class="flex h-12 w-12 items-center justify-center rounded-2xl border border-accent/40 bg-accent/10 text-accent-light shadow-inner shadow-cyan-400/20">
+                <Icon icon={icon} class="h-6 w-6" />
+              </span>
+              <span class="text-xl font-semibold text-white">{tool.name}</span>
+            </span>
+            <p class="flex-1 text-sm leading-relaxed text-slate-300">{tool.description}</p>
+            <span class="inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-widest text-accent-light">
+              {tool.ctaLabel ?? 'Open resource'}
+              <Icon icon={arrow} class="h-4 w-4 transition-transform group-hover:translate-x-1 group-focus-within:translate-x-1" />
+            </span>
+          </a>
+        </article>
+      );
+    })}
+  </div>
+</section>

--- a/src/data/tools.ts
+++ b/src/data/tools.ts
@@ -1,0 +1,35 @@
+import type { IconName } from '~/utils/iconPaths';
+
+export interface Tool {
+  name: string;
+  description: string;
+  href: string;
+  icon: IconName;
+  ctaLabel?: string;
+}
+
+export const tools: Tool[] = [
+  {
+    name: 'NeoGradleTemplate',
+    description: 'Production-ready Gradle service skeleton with CI, observability, and hardening baked in.',
+    href: 'https://github.com/hackall360/NeoGradleTemplate',
+    icon: 'gitPullRequest',
+    ctaLabel: 'View template'
+  },
+  {
+    name: 'Dotfiles',
+    description: 'Opinionated development environment bootstrap with linting, Git hooks, and secrets hygiene.',
+    href: 'https://github.com/hackall360/dotfiles',
+    icon: 'github',
+    ctaLabel: 'Explore dotfiles'
+  },
+  {
+    name: 'Incident CLI',
+    description: 'Terminal toolkit for opening incidents, syncing timelines, and paging crews with a single command.',
+    href: 'https://github.com/hackall360/incident-cli',
+    icon: 'terminal',
+    ctaLabel: 'Open the CLI'
+  }
+];
+
+export default tools;

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseLayout from '~/layouts/BaseLayout.astro';
 import Hero from '~/components/Hero.astro';
 import MetricsStrip from '~/components/MetricsStrip.astro';
 import FeaturedProjects from '~/components/FeaturedProjects.astro';
+import Tools from '~/components/Tools.astro';
 
 const structuredData = {
   '@context': 'https://schema.org',
@@ -25,6 +26,7 @@ const structuredData = {
     <Hero />
     <MetricsStrip />
     <FeaturedProjects />
+    <Tools />
     <section class="rounded-3xl border border-slate-800/40 bg-slate-900/40 p-8 text-slate-100 shadow-lg backdrop-blur">
       <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div class="max-w-2xl space-y-3">

--- a/src/utils/iconPaths.ts
+++ b/src/utils/iconPaths.ts
@@ -11,7 +11,8 @@ export type IconName =
   | 'gitPullRequest'
   | 'star'
   | 'fork'
-  | 'arrowUpRight';
+  | 'arrowUpRight'
+  | 'terminal';
 
 export const ICONS: Record<IconName, IconDefinition> = {
   email: {
@@ -66,6 +67,13 @@ export const ICONS: Record<IconName, IconDefinition> = {
     viewBox: '0 0 24 24',
     paths: [
       'M18.25 15.5a.75.75 0 0 1-.75-.75V7.56L7.28 17.78a.749.749 0 0 1-1.275-.326.749.749 0 0 1 .215-.734L16.44 6.5H9.25a.75.75 0 0 1 0-1.5h9a.75.75 0 0 1 .75.75v9a.75.75 0 0 1-.75.75Z'
+    ]
+  },
+  terminal: {
+    viewBox: '0 0 24 24',
+    paths: [
+      'M5.47 8.47a.75.75 0 0 1 1.06 0l3.75 3.75a.75.75 0 0 1 0 1.06l-3.75 3.75a.75.75 0 1 1-1.06-1.06L8.69 12 5.47 8.81a.75.75 0 0 1 0-1.06Z',
+      'M12.75 15.5a.75.75 0 0 1 .75-.75h5.5a.75.75 0 0 1 0 1.5h-5.5a.75.75 0 0 1-.75-.75Z'
     ]
   }
 };


### PR DESCRIPTION
## Summary
- add a reusable Tools component powered by dedicated metadata
- surface the new tooling showcase on the home page
- extend the shared icon set to cover a terminal glyph for CLI resources

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68fae561a354832fa23a6b653dd4f2f1