### PR TITLE
Improve focus states and QA guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,23 @@ npm run build
 npm run preview
 ```
 
+The static build publishes to `dist/`. When you need the legacy GitHub Pages flow that serves from `/docs`, copy the contents of `dist/` into `docs/`—the hashed assets stay under `docs/_astro/` so existing cache policies remain valid.
+
+## Accessibility & performance QA
+
+Run automated accessibility and performance checks against a local build before shipping changes:
+
+```bash
+npm run build
+npm run preview -- --host
+npx @axe-core/cli http://localhost:4321 --exit
+npx lighthouse http://localhost:4321 --preset=desktop --chrome-flags="--headless" --output=json --output-path=./.lighthouse-report.json
+```
+
+- Axe must report **0 violations**. Investigate and resolve any failures before merging.
+- Lighthouse scores should stay at or above **Performance ≥ 95**, **Accessibility = 100**, **Best Practices ≥ 95**, and **SEO = 100**.
+- Attach reports or key findings to the pull request description so reviewers can see the latest results.
+
 ## Manual GitHub Pages deploy (fallback when Actions are unavailable)
 
 1. Run `npm run build` to generate the static site inside `dist/`.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -127,6 +127,16 @@ function clientScriptPlugin() {
 export default defineConfig({
   site: 'https://hackall360.github.io',
   outDir: './dist',
+  build: {
+    assetsDir: '_astro',
+    rollupOptions: {
+      output: {
+        entryFileNames: '_astro/[name].[hash].js',
+        chunkFileNames: '_astro/[name].[hash].js',
+        assetFileNames: '_astro/[name].[hash][extname]'
+      }
+    }
+  },
   vite: {
     build: {
       assetsInlineLimit: 0

--- a/src/components/AssistantIsland.astro
+++ b/src/components/AssistantIsland.astro
@@ -36,7 +36,7 @@ const assistantEnabled = Boolean(apiUrl && apiToken);
           </div>
           <button
             type="submit"
-            class="inline-flex items-center justify-center gap-2 rounded-xl border border-accent/60 bg-accent/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-accent-light transition hover:bg-accent/30"
+            class="inline-flex items-center justify-center gap-2 rounded-xl border border-accent/60 bg-accent/20 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-accent-light transition hover:bg-accent/30 focus-visible:outline-none focus-visible:focus-ring-accent"
           >
             Ask the assistant
           </button>

--- a/src/components/FeaturedProjects.astro
+++ b/src/components/FeaturedProjects.astro
@@ -28,7 +28,7 @@ const featured = projectList.filter((project) => project.featured).slice(0, 5);
       </div>
       <a
         href="/projects"
-        class="inline-flex items-center justify-center rounded-full border border-accent/30 px-5 py-2.5 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none"
+        class="inline-flex items-center justify-center rounded-full border border-accent/30 px-5 py-2.5 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none focus-visible:focus-ring-accent"
       >
         Browse all projects
       </a>
@@ -77,8 +77,8 @@ const featured = projectList.filter((project) => project.featured).slice(0, 5);
                   href={link.href}
                   class={`inline-flex items-center justify-center rounded-full px-5 py-2 text-sm font-semibold transition duration-200 ease-spring-out focus-visible:outline-none ${
                     index === 0
-                      ? 'border border-transparent bg-accent text-slate-950 shadow-sm shadow-accent/30 hover:bg-accent-light'
-                      : 'border border-accent/25 bg-surface-overlay/80 text-neutral-emphasis hover:border-accent hover:text-accent-light'
+                      ? 'border border-transparent bg-accent text-slate-950 shadow-sm shadow-accent/30 hover:bg-accent-light focus-visible:focus-ring-accent'
+                      : 'border border-accent/25 bg-surface-overlay/80 text-neutral-emphasis hover:border-accent hover:text-accent-light focus-visible:focus-ring-accent'
                   }`}
                   rel={link.href.startsWith('http') ? 'noopener noreferrer' : undefined}
                 >

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -64,7 +64,7 @@ const arrowIcon = ICONS.arrowUpRight;
           return action.type === 'copy' ? (
             <button
               type="button"
-              class="group flex w-full items-center justify-between gap-3 rounded-2xl border border-slate-700/60 bg-slate-950/40 px-4 py-3 text-left font-mono text-xs uppercase tracking-[0.35em] text-slate-300 transition hover:border-accent/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+              class="group flex w-full items-center justify-between gap-3 rounded-2xl border border-slate-700/60 bg-slate-950/40 px-4 py-3 text-left font-mono text-xs uppercase tracking-[0.35em] text-slate-300 transition hover:border-accent/70 focus-visible:outline-none focus-visible:focus-ring-accent"
               data-copy={action.value}
             >
               <span class="flex w-full items-center gap-3 text-[0.7rem] tracking-[0.4em]">
@@ -80,7 +80,7 @@ const arrowIcon = ICONS.arrowUpRight;
             </button>
           ) : (
             <a
-              class="group flex w-full items-center justify-between gap-3 rounded-2xl border border-slate-700/60 bg-slate-950/40 px-4 py-3 text-left font-mono text-xs uppercase tracking-[0.35em] text-slate-300 transition hover:border-accent/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+              class="group flex w-full items-center justify-between gap-3 rounded-2xl border border-slate-700/60 bg-slate-950/40 px-4 py-3 text-left font-mono text-xs uppercase tracking-[0.35em] text-slate-300 transition hover:border-accent/70 focus-visible:outline-none focus-visible:focus-ring-accent"
               href={action.href}
               target="_blank"
               rel="noopener noreferrer"

--- a/src/components/MetricsStrip.astro
+++ b/src/components/MetricsStrip.astro
@@ -29,7 +29,7 @@ const metrics: Array<{ label: string; value: string; description: string }> = [
           data-motion-child
           data-motion-direction="up"
           tabindex="0"
-          class="group rounded-3xl border border-accent/15 bg-surface-highlight/60 p-6 text-left shadow-inner-terminal transition duration-300 ease-spring-out hover:border-accent/60 focus-visible:outline-none focus-visible:shadow-glow"
+          class="group rounded-3xl border border-accent/15 bg-surface-highlight/60 p-6 text-left shadow-inner-terminal transition duration-300 ease-spring-out hover:border-accent/60 focus-visible:outline-none focus-visible:shadow-glow focus-visible:focus-ring-accent"
         >
           <h3 class="text-3xl font-semibold text-white sm:text-4xl" aria-label={`${metric.value} ${metric.label}`}>
             {metric.value}

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -23,6 +23,7 @@ const links: Array<{ href: string; label: string; comingSoon?: boolean }> = [
           class:list={[
             'rounded-md border border-accent/15 px-3 py-1 transition-colors duration-200 ease-spring-out focus-visible:outline-none',
             'hover:border-accent hover:bg-accent/10 hover:text-accent-light',
+            'focus-visible:focus-ring-accent focus-visible:border-accent focus-visible:text-accent-light',
             item.comingSoon && 'pointer-events-none opacity-50'
           ]}
           href={item.href}

--- a/src/components/ProjectCard.astro
+++ b/src/components/ProjectCard.astro
@@ -43,7 +43,7 @@ const detailUrl = `/projects/${project.slug}`;
       <span class="text-neutral-emphasis normal-case">{project.role}</span>
     </div>
     <h3 class="break-words text-xl font-semibold text-white transition group-hover:text-accent-light">
-      <a class="break-words outline-none focus-visible:outline-none" href={detailUrl}>
+      <a class="break-words outline-none focus-visible:focus-ring-accent focus-visible:outline-none" href={detailUrl}>
         {project.title}
       </a>
     </h3>
@@ -79,14 +79,14 @@ const detailUrl = `/projects/${project.slug}`;
 
   <footer class="mt-6 flex flex-wrap items-center gap-3">
     <a
-      class="inline-flex items-center justify-center gap-3 rounded-full border border-accent/25 bg-surface-overlay/80 px-4 py-2 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none"
+      class="inline-flex items-center justify-center gap-3 rounded-full border border-accent/25 bg-surface-overlay/80 px-4 py-2 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none focus-visible:focus-ring-accent"
       href={detailUrl}
     >
       View case study
     </a>
     {primaryLink && (
       <a
-        class="inline-flex items-center justify-center gap-3 rounded-full border border-transparent bg-accent px-4 py-2 text-sm font-semibold text-slate-950 shadow-sm shadow-accent/30 transition duration-200 ease-spring-out hover:bg-accent-light focus-visible:outline-none"
+        class="inline-flex items-center justify-center gap-3 rounded-full border border-transparent bg-accent px-4 py-2 text-sm font-semibold text-slate-950 shadow-sm shadow-accent/30 transition duration-200 ease-spring-out hover:bg-accent-light focus-visible:outline-none focus-visible:focus-ring-accent"
         href={primaryLink.href}
         rel={primaryLink.href.startsWith('http') ? 'noreferrer noopener' : undefined}
       >
@@ -95,7 +95,7 @@ const detailUrl = `/projects/${project.slug}`;
     )}
     {secondaryLinks.map((link) => (
       <a
-        class="inline-flex items-center justify-center gap-3 rounded-full border border-accent/25 bg-surface-overlay/80 px-4 py-2 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none"
+        class="inline-flex items-center justify-center gap-3 rounded-full border border-accent/25 bg-surface-overlay/80 px-4 py-2 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none focus-visible:focus-ring-accent"
         href={link.href}
         rel={link.href.startsWith('http') ? 'noreferrer noopener' : undefined}
       >

--- a/src/components/ProjectFilters.astro
+++ b/src/components/ProjectFilters.astro
@@ -15,7 +15,7 @@ const { tags } = Astro.props as Props;
     <h2 class="text-lg font-semibold text-white">Filter by focus area</h2>
     <button
       type="button"
-      class="self-start rounded-full border border-transparent bg-surface-highlight/70 px-4 py-2 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none"
+      class="self-start rounded-full border border-transparent bg-surface-highlight/70 px-4 py-2 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none focus-visible:focus-ring-accent"
       data-clear-filters
     >
       Clear filters
@@ -25,7 +25,7 @@ const { tags } = Astro.props as Props;
     {tags.map((tag) => (
       <button
         type="button"
-        class="tag-filter inline-flex items-center gap-2 rounded-full border border-accent/20 bg-surface-overlay/80 px-4 py-2 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none"
+        class="tag-filter inline-flex items-center gap-2 rounded-full border border-accent/20 bg-surface-overlay/80 px-4 py-2 text-sm font-semibold text-neutral-emphasis transition duration-200 ease-spring-out hover:border-accent hover:text-accent-light focus-visible:outline-none focus-visible:focus-ring-accent"
         data-tag={tag.toLowerCase()}
         aria-pressed="false"
       >

--- a/src/components/SecurityStance.astro
+++ b/src/components/SecurityStance.astro
@@ -70,7 +70,7 @@ const signals: Signal[] = [
               <p class="text-sm leading-relaxed text-emerald-100/80">{signal.description}</p>
             </div>
             <a
-              class="mt-auto inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-widest text-emerald-200 transition hover:text-emerald-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-300"
+              class="mt-auto inline-flex items-center gap-2 text-sm font-semibold uppercase tracking-widest text-emerald-200 transition hover:text-emerald-100 focus-visible:outline-none focus-visible:focus-ring-accent"
               href={signal.link.href}
               target={isExternal ? '_blank' : undefined}
               rel={isExternal ? 'noopener noreferrer' : undefined}

--- a/src/components/Tools.astro
+++ b/src/components/Tools.astro
@@ -28,7 +28,7 @@ const sectionTitleId = `tools-heading-${Math.random().toString(36).slice(2, 7)}`
           role="listitem"
         >
           <a
-            class="group flex h-full flex-col gap-6 p-6 text-left focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+            class="group flex h-full flex-col gap-6 p-6 text-left focus-visible:outline-none focus-visible:focus-ring-accent"
             href={tool.href}
             target="_blank"
             rel="noopener noreferrer"

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -50,6 +50,25 @@
     outline: none;
     box-shadow: none;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+
+    [data-motion-reveal],
+    [data-motion-child],
+    [data-motion-group] {
+      transform: none !important;
+      transition: none !important;
+      animation: none !important;
+    }
+  }
 }
 
 .code-inline {


### PR DESCRIPTION
## Summary
- force hashed filenames for emitted `_astro` assets while keeping the CI deployment path unchanged
- add consistent focus-visible treatments across interactive components and harden reduced-motion fallbacks
- document the required axe and Lighthouse QA checks, including target scores and legacy `/docs` fallback notes

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68fb7e262b68832f880582db079fd936