### PR TITLE
docs: describe branch protections and add manual publish script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,12 @@ Thanks for helping improve the site! A few conventions keep the workflow reprodu
 2. Install dependencies with `npm ci` to honor the checked-in `package-lock.json`.
 3. Copy `.env.local.example` to `.env.local` and fill in any required values (see below).
 
+## Branch protection and reviews
+
+- The `main` branch is protected—open a pull request for every change instead of pushing directly.
+- Required status checks must succeed when GitHub Actions is enabled. Keep the default deployment workflow (and any future CI jobs) green so merges are unblocked.
+- If CI is paused temporarily, the pull-request requirement remains but the status checks clear automatically after the queue drains.
+
 ## Dependency management
 
 - Never delete `package-lock.json`. It captures the exact dependency graph GitHub Actions uses to deploy the site.
@@ -25,14 +31,12 @@ GITHUB_TOKEN="<token>" npm run fetch-projects
 
 The script reads configuration from environment variables. The `.env.local.example` file outlines the supported keys, including optional filters, cache controls, and topic naming conventions.
 
-## Optional: Docs-based Pages publishing
+## Manual GitHub Pages publishes
 
-The default deployment path relies on GitHub Actions, but if you temporarily switch back to the Docs-based GitHub Pages flow, add the following Git hook to avoid forgetting the static build:
+Automated deploys are handled by GitHub Actions, but the repository keeps a manual escape hatch for emergencies. Run the helper script when CI is unavailable:
 
 ```bash
-# .git/hooks/pre-commit
-npm run build
-git add docs
+npm run publish:docs
 ```
 
-Make the hook executable with `chmod +x .git/hooks/pre-commit`. Remove it once you return to the CI-driven publish flow.
+The script builds the site, refreshes a temporary `gh-pages` worktree, commits any changes, and pushes to `origin/gh-pages`. To customize the destination branch or commit message, export `PUBLISH_BRANCH` or `PUBLISH_COMMIT_MESSAGE` before invoking the command. The script refuses to run in CI so manual publishes stay an explicit, local action.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,22 @@ npx lighthouse http://localhost:4321 --preset=desktop --chrome-flags="--headless
 
 The automated workflow should be re-enabled as soon as possible so future deploys stay reproducible.
 
+### Branch protection and release gates
+
+- All changes land on `main` via pull requests. Direct pushes are disabled so reviewers can sign off on every deploy.
+- When GitHub Actions is active, required status checks must pass before the merge button unlocks. Keep the default `Deploy site` workflow (and any additional CI jobs) healthy so branch protection rules can succeed.
+- When CI is paused, the rules still require a pull request, but the status-check requirement automatically clears once no workflows are queued.
+
+### Manual publish helper
+
+Run `npm run publish:docs` when you need the scripted fallback instead of the step-by-step instructions above. The helper does the following:
+
+1. Builds the static assets (`npm run build`).
+2. Refreshes a temporary `gh-pages` worktree in `.publish-gh-pages/`.
+3. Copies `dist/` into the worktree, commits, and pushes to `origin/gh-pages` when files changed.
+
+Override the target branch or commit message by exporting `PUBLISH_BRANCH` or `PUBLISH_COMMIT_MESSAGE` before invoking the script. The helper refuses to run in CI so the manual flow stays a deliberate, local-only action.
+
 ## Notes collection
 
 - Markdown notes live in `src/content/notes/` and follow the schema defined in `src/content/config.ts`.

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "sync": "astro sync",
     "preview": "astro preview",
     "astro:check": "astro check",
-    "fetch-projects": "node ./scripts/fetch-projects.mjs"
+    "fetch-projects": "node ./scripts/fetch-projects.mjs",
+    "publish:docs": "./scripts/publish.sh"
   },
   "dependencies": {
     "astro": "^4.16.12",

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ ${CI:-} == "true" ]]; then
+  echo "publish.sh: refusing to run inside CI. Run this script locally." >&2
+  exit 1
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DIST_DIR="$ROOT_DIR/dist"
+WORKTREE_DIR="$ROOT_DIR/.publish-gh-pages"
+PUBLISH_BRANCH="${PUBLISH_BRANCH:-gh-pages}"
+COMMIT_MESSAGE="${PUBLISH_COMMIT_MESSAGE:-chore: publish docs}" 
+
+cd "$ROOT_DIR"
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "publish.sh: npm is required but was not found in PATH." >&2
+  exit 1
+fi
+
+npm run build
+
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "publish.sh: script must be run inside a Git repository." >&2
+  exit 1
+fi
+
+if ! git ls-remote --exit-code --heads origin "$PUBLISH_BRANCH" >/dev/null 2>&1; then
+  cat >&2 <<MSG
+publish.sh: could not find remote branch '$PUBLISH_BRANCH'.
+Ensure the GitHub Pages branch exists and try again.
+MSG
+  exit 1
+fi
+
+git fetch origin "$PUBLISH_BRANCH"
+
+if git worktree list --porcelain | grep -q "$WORKTREE_DIR"; then
+  git worktree remove "$WORKTREE_DIR" --force
+fi
+
+if git show-ref --verify --quiet "refs/heads/$PUBLISH_BRANCH"; then
+  git branch -f "$PUBLISH_BRANCH" "origin/$PUBLISH_BRANCH"
+else
+  git branch "$PUBLISH_BRANCH" "origin/$PUBLISH_BRANCH"
+fi
+
+git worktree add "$WORKTREE_DIR" "$PUBLISH_BRANCH"
+trap 'git worktree remove "$WORKTREE_DIR" --force' EXIT
+
+rm -rf "$WORKTREE_DIR"/*
+cp -R "$DIST_DIR"/. "$WORKTREE_DIR"/
+
+pushd "$WORKTREE_DIR" >/dev/null
+
+git add --all
+if git diff --quiet --cached; then
+  echo "publish.sh: no changes to publish."
+else
+  git commit -m "$COMMIT_MESSAGE"
+  git push origin "$PUBLISH_BRANCH"
+  echo "publish.sh: published updated docs to '$PUBLISH_BRANCH'."
+fi
+
+popd >/dev/null


### PR DESCRIPTION
## Summary
- document branch protection requirements and how status checks gate merges when CI is active
- add a reusable publish.sh helper and wire it to the optional npm run publish:docs command
- teach README and CONTRIBUTING how to run the scripted fallback release flow

## Testing
- npm run astro:check

------
https://chatgpt.com/codex/tasks/task_b_68fba6907b04832f8f322d739e774437